### PR TITLE
Fix curl_close warning on PHP 8+ by adding version check

### DIFF
--- a/Helpers/Mail365Client.php
+++ b/Helpers/Mail365Client.php
@@ -41,7 +41,10 @@ class Mail365Client
             $body     = curl_exec($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $curlErr  = curl_error($ch);
-            curl_close($ch);
+
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            }
 
             if ($curlErr) {
                 if ($attempt < $maxRetries) {

--- a/Transport/Graph365Transport.php
+++ b/Transport/Graph365Transport.php
@@ -304,7 +304,10 @@ class Graph365Transport implements Swift_Transport
             $body     = curl_exec($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $curlErr  = curl_error($ch);
-            curl_close($ch);
+
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            }
 
             if ($curlErr) {
                 throw new \Swift_TransportException("Attachment upload failed: {$curlErr}");


### PR DESCRIPTION
On PHP 8.0 and above, calling curl_close($ch) was triggering a warning that the module treats as an error, causing the script to fail.

This change wraps the curl_close call inside a condition that only executes it for PHP versions lower than 8.0.0 (PHP_VERSION_ID < 80000). For PHP 8 or later, the call is skipped, avoiding the warning and restoring correct functionality.

No other changes are required.